### PR TITLE
Remove SG Review menu (no longer supported in RV)

### DIFF
--- a/env/site.yml
+++ b/env/site.yml
@@ -44,8 +44,6 @@ engines:
           timecode: automatic
           frame: 1001
     menu_overrides:
-      SG Review:
-      - {app_instance: tk-multi-importcut, name: Import Cut}
       Tools:
       - {app_instance: tk-multi-pythonconsole, name: PTR Python Console...}
     debug_logging: false


### PR DESCRIPTION
Remove SG Review (no longer supported in RV)

Note that the tk-multi-importcut app is still used in RV but under the 'Flow Protection Tracking' menu (this is already working fine).
This extra SG Review menu is no longer needed nor supported in RV.