### PR TITLE
Remove duplicate Import Cut option in Flow Production Tracking menu

### DIFF
--- a/env/site.yml
+++ b/env/site.yml
@@ -44,8 +44,10 @@ engines:
           timecode: automatic
           frame: 1001
     menu_overrides:
+      SG Review:
+        - {app_instance: tk-multi-importcut, name: Import Cut}
       Tools:
-      - {app_instance: tk-multi-pythonconsole, name: PTR Python Console...}
+        - {app_instance: tk-multi-pythonconsole, name: PTR Python Console...}
     debug_logging: false
     location:
       type: app_store


### PR DESCRIPTION
When working on the rebranding of Toolkit inside Flow Production Tracking RV 2024.1, we had an issue were the deprecated "SG Review" package would re-enable itself and be displayed in RV's top menu along with its "Import Cut" option. This has been resolved. However, the "Import Cut" option has now been moved into the "Flow Production Tracking" menu, hence, creating a second Import Cut option in the menu. It should be removed since we already have the "Launch Import Cut Tool" option available.

![image](https://github.com/shotgunsoftware/tk-config-rv/assets/85132405/2d2fb2e4-43ff-4821-9d98-4e92e84ecf25)

Should be merged in tandem with [this](https://github.com/shotgunsoftware/tk-rv/pull/32) PR in `tk-rv`. 

This PR as well as the PR linked above will eventually replace changes made directly in RV to `tk-config-rv` and `tk-rv` after adequate testing has been done.